### PR TITLE
fix: OS の読み上げ機能に向けた label 付与 + リファクタリング #16

### DIFF
--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -304,7 +304,7 @@ export default function Simulator() {
                 <th className="w-20">ビルド名</th>
                 <td className="w-8"></td>
                 <td>
-                  <input className="w-80 text-black" type="text" value={buildName} autoFocus onChange={e => setBuildName(e.target.value)} />
+                  <input className="w-80 text-black" type="text" value={buildName} autoFocus placeholder='例：上質ビルド' onChange={e => setBuildName(e.target.value)} />
                 </td>
               </tr>
 

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -185,6 +185,37 @@ function setDocumentTitle(name: string) {
   }
 }
 
+const sliderClass = "w-28 md:w-40 lg:w-60 m-2"
+const buttonClass = "bg-white text-black p-0.5 md:p-1 m-0.5 md:m-1 rounded w-10 md:w-12"
+
+function setValueWithValidation(value: number, setValue: any, min: number, max: number) {
+  if (value < min) {
+    setValue(min)
+    return
+  }
+
+  if (max < value) {
+    setValue(max)
+    return
+  }
+
+  setValue(value)
+}
+
+const Slider = ({value, max, setValue}: {value: number, max: number, setValue: any}) => {
+  return (
+    <input
+      className={sliderClass}
+      type="range"
+      min="0"
+      max={max}
+      step="1"
+      value={value}
+      onChange={e => setValue(parseInt(e.target.value))}
+      />
+  )
+}
+
 export default function Simulator() {
   const searchParams = useSearchParams()
   const defaultBuild = searchParams.get("bld") || ""
@@ -222,22 +253,6 @@ export default function Simulator() {
     setBloodtinge(0)
     setArcane(0)
   }
-
-  function setValueWithValidation(value: number, setValue: any, min: number, max: number) {
-    if (value < min) {
-      setValue(min)
-      return
-    }
-
-    if (max < value) {
-      setValue(max)
-      return
-    }
-
-    setValue(value)
-  }
-
-  const buttonClass = "bg-white text-black p-0.5 md:p-1 m-0.5 md:m-1 rounded w-10 md:w-12"
 
   const VitalityButton = ({value, text}: {value: number, text: string}) => {
     return (
@@ -286,7 +301,6 @@ export default function Simulator() {
     setDocumentTitle(buildName)
   })
 
-  const sliderClass = "w-28 md:w-40 lg:w-60 m-2"
   const shareURL = generateURL(buildName, searchOriginIndex(selected), vitality, endurance, strength, skill, bloodtinge, arcane)
 
   return (
@@ -328,16 +342,7 @@ export default function Simulator() {
                 <td>
                   <VitalityButton value={-10} text="-10"/>
                   <VitalityButton value={-1} text="-1"/>
-                  {/* 何故かスライダーを関数化して共通化すると、ドラッグで固まるようになるので仕方なくベタ書き */}
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxVitality}
-                    step="1"
-                    value={vitality}
-                    onChange={e => setVitality(parseInt(e.target.value))}
-                    />
+                  <Slider value={vitality} max={maxVitality} setValue={setVitality}/>
                   <VitalityButton value={+1} text="+1"/>
                   <VitalityButton value={+10} text="+10"/>
                 </td>
@@ -351,15 +356,7 @@ export default function Simulator() {
                 <td>
                   <EnduranceButton value={-10} text="-10"/>
                   <EnduranceButton value={-1} text="-1"/>
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxEndurance}
-                    step="1"
-                    value={endurance}
-                    onChange={e => setEndurance(parseInt(e.target.value))}
-                    />
+                  <Slider value={endurance} max={maxEndurance} setValue={setEndurance}/>
                   <EnduranceButton value={+1} text="+1"/>
                   <EnduranceButton value={+10} text="+10"/>
                 </td>
@@ -373,15 +370,7 @@ export default function Simulator() {
                 <td>
                   <StrengthButton value={-10} text="-10"/>
                   <StrengthButton value={-1} text="-1"/>
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxStrength}
-                    step="1"
-                    value={strength}
-                    onChange={e => setStrength(parseInt(e.target.value))}
-                    />
+                  <Slider value={strength} max={maxStrength} setValue={setStrength}/>
                   <StrengthButton value={+1} text="+1"/>
                   <StrengthButton value={+10} text="+10"/>
                 </td>
@@ -395,15 +384,7 @@ export default function Simulator() {
                 <td>
                   <SkillButton value={-10} text="-10"/>
                   <SkillButton value={-1} text="-1"/>
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxSkill}
-                    step="1"
-                    value={skill}
-                    onChange={e => setSkill(parseInt(e.target.value))}
-                    />
+                  <Slider value={skill} max={maxSkill} setValue={setSkill}/>
                   <SkillButton value={+1} text="+1"/>
                   <SkillButton value={+10} text="+10"/>
                 </td>
@@ -417,15 +398,7 @@ export default function Simulator() {
                 <td>
                   <BloodtingeButton value={-10} text="-10"/>
                   <BloodtingeButton value={-1} text="-1"/>
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxBloodtinge}
-                    step="1"
-                    value={bloodtinge}
-                    onChange={e => setBloodtinge(parseInt(e.target.value))}
-                    />
+                  <Slider value={bloodtinge} max={maxBloodtinge} setValue={setBloodtinge}/>
                   <BloodtingeButton value={+1} text="+1"/>
                   <BloodtingeButton value={+10} text="+10"/>
                 </td>
@@ -439,15 +412,7 @@ export default function Simulator() {
                 <td>
                   <ArcaneButton value={-10} text="-10"/>
                   <ArcaneButton value={-1} text="-1"/>
-                  <input
-                    className={sliderClass}
-                    type="range"
-                    min="0"
-                    max={maxArcane}
-                    step="1"
-                    value={arcane}
-                    onChange={e => setArcane(parseInt(e.target.value))}
-                    />
+                  <Slider value={arcane} max={maxArcane} setValue={setArcane}/>
                   <ArcaneButton value={+1} text="+1"/>
                   <ArcaneButton value={+10} text="+10"/>
                 </td>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -304,7 +304,7 @@ export default function Simulator() {
                 <th className="w-20">ビルド名</th>
                 <td className="w-8"></td>
                 <td>
-                  <input className="w-80 text-black" type="text" value={buildName} autoFocus placeholder='例：上質ビルド' onChange={e => setBuildName(e.target.value)} />
+                  <input className="w-80 text-black" type="text" value={buildName} autoFocus placeholder='例：上質ビルド' aria-label='分かりやすいビルド名を入力します' onChange={e => setBuildName(e.target.value)} />
                 </td>
               </tr>
 
@@ -312,7 +312,7 @@ export default function Simulator() {
                 <th>過去</th>
                 <td></td>
                 <td>
-                  <select data-testid="originText" className="text-black" value={selected} onChange={e => resetStatus(e.target.value)}>
+                  <select data-testid="originText" className="text-black" value={selected} aria-label='過去を選択します' onChange={e => resetStatus(e.target.value)}>
                     {
                       numberToOrigin.map((v,i) => <option key={v.key} value={v.key}>{v.name}</option>)
                     }

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -202,13 +202,18 @@ function setValueWithValidation(value: number, setValue: any, min: number, max: 
   setValue(value)
 }
 
-const IncreaseAndDecreaseButton = ({currentValue, value, max, text, setValue}: {currentValue: number, value: number,  max: number, text: string, setValue: Dispatch<SetStateAction<number>>}) => {
+const IncreaseAndDecreaseButton = ({statusName, currentValue, additionalValue, value, max, text, setValue}: {statusName: string, currentValue: number, additionalValue: number, value: number,  max: number, text: string, setValue: Dispatch<SetStateAction<number>>}) => {
   return (
-    <button type="button" className={buttonClass} onClick={e => setValueWithValidation(currentValue + value, setValue, 0, max)}>{text}</button>
+    <button
+      type="button"
+      className={buttonClass}
+      aria-label={`${statusName}の値を ${value} します。現在の値は ${currentValue} です`}
+      onClick={e => setValueWithValidation(additionalValue + value, setValue, 0, max)}
+      >{text}</button>
   )
 }
 
-const Slider = ({value, max, setValue}: {value: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
+const Slider = ({statusName, currentValue, value, max, setValue}: {statusName: string, currentValue: number, value: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
   return (
     <input
       className={sliderClass}
@@ -217,19 +222,20 @@ const Slider = ({value, max, setValue}: {value: number, max: number, setValue: D
       max={max}
       step="1"
       value={value}
+      aria-label={`${statusName}の値をスライダーで増減します。現在の値は ${currentValue} です`}
       onChange={e => setValue(parseInt(e.target.value))}
       />
   )
 }
 
-const ChangeParameterInputs = ({currentValue, max, setValue}: {currentValue: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
+const ChangeParameterInputs = ({statusName, currentValue, additionalValue, max, setValue}: {statusName: string, currentValue: number, additionalValue: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
   return (
     <>
-      <IncreaseAndDecreaseButton currentValue={currentValue} value={-10} max={max} text='-10' setValue={setValue} />
-      <IncreaseAndDecreaseButton currentValue={currentValue} value={-1} max={max} text='-1' setValue={setValue} />
-      <Slider value={currentValue} max={max} setValue={setValue}/>
-      <IncreaseAndDecreaseButton currentValue={currentValue} value={+1} max={max} text='+1' setValue={setValue} />
-      <IncreaseAndDecreaseButton currentValue={currentValue} value={+10} max={max} text='+10' setValue={setValue} />
+      <IncreaseAndDecreaseButton statusName={statusName} currentValue={currentValue} additionalValue={additionalValue} value={-10} max={max} text='-10' setValue={setValue} />
+      <IncreaseAndDecreaseButton statusName={statusName} currentValue={currentValue} additionalValue={additionalValue} value={-1} max={max} text='-1' setValue={setValue} />
+      <Slider statusName={statusName} currentValue={currentValue} value={additionalValue} max={max} setValue={setValue}/>
+      <IncreaseAndDecreaseButton statusName={statusName} currentValue={currentValue} additionalValue={additionalValue} value={+1} max={max} text='+1' setValue={setValue} />
+      <IncreaseAndDecreaseButton statusName={statusName} currentValue={currentValue} additionalValue={additionalValue} value={+10} max={max} text='+10' setValue={setValue} />
     </>
   )
 }
@@ -318,20 +324,20 @@ export default function Simulator() {
 
               {
                 [
-                  {desc: '体力', id: 'vitalityText', selected: selectedOrigin.vitality, currentValue: vitality, max: maxVitality, setValue: setVitality},
-                  {desc: '持久力', id: 'enduranceText', selected: selectedOrigin.endurance, currentValue: endurance, max: maxEndurance, setValue: setEndurance},
-                  {desc: '筋力', id: 'strengthText', selected: selectedOrigin.strength, currentValue: strength, max: maxStrength, setValue: setStrength},
-                  {desc: '技術', id: 'skillText', selected: selectedOrigin.skill, currentValue: skill, max: maxSkill, setValue: setSkill},
-                  {desc: '血質', id: 'bloodtingeText', selected: selectedOrigin.bloodtinge, currentValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
-                  {desc: '神秘', id: 'arcaneText', selected: selectedOrigin.arcane, currentValue: arcane, max: maxArcane, setValue: setArcane},
+                  {desc: '体力', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
+                  {desc: '持久力', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
+                  {desc: '筋力', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
+                  {desc: '技術', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
+                  {desc: '血質', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
+                  {desc: '神秘', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
                 ].map((v) => (
                   <tr key={v.id}>
                     <th>{v.desc}</th>
                     <td data-testid={v.id}>
-                      {v.selected + v.currentValue}
+                      {v.baseValue + v.additionalValue}
                     </td>
                     <td>
-                      <ChangeParameterInputs currentValue={v.currentValue} max={v.max} setValue={v.setValue} />
+                      <ChangeParameterInputs statusName={v.desc} currentValue={v.baseValue + v.additionalValue} additionalValue={v.additionalValue} max={v.max} setValue={v.setValue} />
                     </td>
                   </tr>
                 ))

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -222,6 +222,18 @@ const Slider = ({value, max, setValue}: {value: number, max: number, setValue: D
   )
 }
 
+const ChangeParameterInputs = ({currentValue, max, setValue}: {currentValue: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
+  return (
+    <>
+      <IncreaseAndDecreaseButton currentValue={currentValue} value={-10} max={max} text='-10' setValue={setValue} />
+      <IncreaseAndDecreaseButton currentValue={currentValue} value={-1} max={max} text='-1' setValue={setValue} />
+      <Slider value={currentValue} max={max} setValue={setValue}/>
+      <IncreaseAndDecreaseButton currentValue={currentValue} value={+1} max={max} text='+1' setValue={setValue} />
+      <IncreaseAndDecreaseButton currentValue={currentValue} value={+10} max={max} text='+10' setValue={setValue} />
+    </>
+  )
+}
+
 export default function Simulator() {
   const searchParams = useSearchParams()
   const defaultBuild = searchParams.get("bld") || ""
@@ -310,11 +322,7 @@ export default function Simulator() {
                   {selectedOrigin.vitality + vitality}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={vitality} value={-10} max={maxVitality} text='-10' setValue={setVitality} />
-                  <IncreaseAndDecreaseButton currentValue={vitality} value={-1} max={maxVitality} text='-1' setValue={setVitality} />
-                  <Slider value={vitality} max={maxVitality} setValue={setVitality}/>
-                  <IncreaseAndDecreaseButton currentValue={vitality} value={+1} max={maxVitality} text='+1' setValue={setVitality} />
-                  <IncreaseAndDecreaseButton currentValue={vitality} value={+10} max={maxVitality} text='+10' setValue={setVitality} />
+                  <ChangeParameterInputs currentValue={vitality} max={maxVitality} setValue={setVitality} />
                 </td>
               </tr>
 
@@ -324,11 +332,7 @@ export default function Simulator() {
                   {selectedOrigin.endurance + endurance}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={endurance} value={-10} max={maxEndurance} text='-10' setValue={setEndurance} />
-                  <IncreaseAndDecreaseButton currentValue={endurance} value={-1} max={maxEndurance} text='-1' setValue={setEndurance} />
-                  <Slider value={endurance} max={maxEndurance} setValue={setEndurance}/>
-                  <IncreaseAndDecreaseButton currentValue={endurance} value={+1} max={maxEndurance} text='+1' setValue={setEndurance} />
-                  <IncreaseAndDecreaseButton currentValue={endurance} value={+10} max={maxEndurance} text='+10' setValue={setEndurance} />
+                  <ChangeParameterInputs currentValue={endurance} max={maxEndurance} setValue={setEndurance} />
                 </td>
               </tr>
 
@@ -338,11 +342,7 @@ export default function Simulator() {
                   {selectedOrigin.strength + strength}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={strength} value={-10} max={maxStrength} text='-10' setValue={setStrength} />
-                  <IncreaseAndDecreaseButton currentValue={strength} value={-1} max={maxStrength} text='-1' setValue={setStrength} />
-                  <Slider value={strength} max={maxStrength} setValue={setStrength}/>
-                  <IncreaseAndDecreaseButton currentValue={strength} value={+1} max={maxStrength} text='+1' setValue={setStrength} />
-                  <IncreaseAndDecreaseButton currentValue={strength} value={+10} max={maxStrength} text='+10' setValue={setStrength} />
+                  <ChangeParameterInputs currentValue={strength} max={maxStrength} setValue={setStrength} />
                 </td>
               </tr>
 
@@ -352,11 +352,7 @@ export default function Simulator() {
                   {selectedOrigin.skill + skill}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={skill} value={-10} max={maxSkill} text='-10' setValue={setSkill} />
-                  <IncreaseAndDecreaseButton currentValue={skill} value={-1} max={maxSkill} text='-1' setValue={setSkill} />
-                  <Slider value={skill} max={maxSkill} setValue={setSkill}/>
-                  <IncreaseAndDecreaseButton currentValue={skill} value={+1} max={maxSkill} text='+1' setValue={setSkill} />
-                  <IncreaseAndDecreaseButton currentValue={skill} value={+10} max={maxSkill} text='+10' setValue={setSkill} />
+                  <ChangeParameterInputs currentValue={skill} max={maxSkill} setValue={setSkill} />
                 </td>
               </tr>
 
@@ -366,11 +362,7 @@ export default function Simulator() {
                   {selectedOrigin.bloodtinge + bloodtinge}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={-10} max={maxBloodtinge} text='-10' setValue={setBloodtinge} />
-                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={-1} max={maxBloodtinge} text='-1' setValue={setBloodtinge} />
-                  <Slider value={bloodtinge} max={maxBloodtinge} setValue={setBloodtinge}/>
-                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={+1} max={maxBloodtinge} text='+1' setValue={setBloodtinge} />
-                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={+10} max={maxBloodtinge} text='+10' setValue={setBloodtinge} />
+                  <ChangeParameterInputs currentValue={bloodtinge} max={maxBloodtinge} setValue={setBloodtinge} />
                 </td>
               </tr>
 
@@ -380,11 +372,7 @@ export default function Simulator() {
                   {selectedOrigin.arcane + arcane}
                 </td>
                 <td>
-                  <IncreaseAndDecreaseButton currentValue={arcane} value={-10} max={maxArcane} text='-10' setValue={setArcane} />
-                  <IncreaseAndDecreaseButton currentValue={arcane} value={-1} max={maxArcane} text='-1' setValue={setArcane} />
-                  <Slider value={arcane} max={maxArcane} setValue={setArcane}/>
-                  <IncreaseAndDecreaseButton currentValue={arcane} value={+1} max={maxArcane} text='+1' setValue={setArcane} />
-                  <IncreaseAndDecreaseButton currentValue={arcane} value={+10} max={maxArcane} text='+10' setValue={setArcane} />
+                  <ChangeParameterInputs currentValue={arcane} max={maxArcane} setValue={setArcane} />
                 </td>
               </tr>
             </tbody>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -304,7 +304,7 @@ export default function Simulator() {
                 <th className="w-20">ビルド名</th>
                 <td className="w-8"></td>
                 <td>
-                  <input className="w-80 text-black" type="text" value={buildName} onChange={e => setBuildName(e.target.value)} />
+                  <input className="w-80 text-black" type="text" value={buildName} autoFocus onChange={e => setBuildName(e.target.value)} />
                 </td>
               </tr>
 

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -328,6 +328,7 @@ export default function Simulator() {
                 <td>
                   <VitalityButton value={-10} text="-10"/>
                   <VitalityButton value={-1} text="-1"/>
+                  {/* 何故かスライダーを関数化して共通化すると、ドラッグで固まるようになるので仕方なくベタ書き */}
                   <input
                     className={sliderClass}
                     type="range"

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -203,11 +203,13 @@ function setValueWithValidation(value: number, setValue: any, min: number, max: 
 }
 
 const IncreaseAndDecreaseButton = ({statusName, currentValue, additionalValue, value, max, text, setValue}: {statusName: string, currentValue: number, additionalValue: number, value: number,  max: number, text: string, setValue: Dispatch<SetStateAction<number>>}) => {
+  const num = Math.abs(value)
+  const op = 0 < value ? '加算' : '減算'
   return (
     <button
       type="button"
       className={buttonClass}
-      aria-label={`${statusName}の値を ${value} します。現在の値は ${currentValue} です`}
+      aria-label={`${statusName}の値を ${num} ${op}します。現在の値は ${currentValue} です`}
       onClick={e => setValueWithValidation(additionalValue + value, setValue, 0, max)}
       >{text}</button>
   )

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Dispatch, SetStateAction } from 'react'
 import { HPs, Staminas } from './data'
 import { useSearchParams } from "next/navigation";
 
@@ -202,7 +202,13 @@ function setValueWithValidation(value: number, setValue: any, min: number, max: 
   setValue(value)
 }
 
-const Slider = ({value, max, setValue}: {value: number, max: number, setValue: any}) => {
+const IncreaseAndDecreaseButton = ({currentValue, value, max, text, setValue}: {currentValue: number, value: number,  max: number, text: string, setValue: Dispatch<SetStateAction<number>>}) => {
+  return (
+    <button type="button" className={buttonClass} onClick={e => setValueWithValidation(currentValue + value, setValue, 0, max)}>{text}</button>
+  )
+}
+
+const Slider = ({value, max, setValue}: {value: number, max: number, setValue: Dispatch<SetStateAction<number>>}) => {
   return (
     <input
       className={sliderClass}
@@ -252,42 +258,6 @@ export default function Simulator() {
     setSkill(0)
     setBloodtinge(0)
     setArcane(0)
-  }
-
-  const VitalityButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(vitality + value, setVitality, 0, maxVitality)}>{text}</button>
-    )
-  }
-
-  const EnduranceButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(endurance + value, setEndurance, 0, maxEndurance)}>{text}</button>
-    )
-  }
-
-  const StrengthButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(strength + value, setStrength, 0, maxStrength)}>{text}</button>
-    )
-  }
-
-  const SkillButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(skill + value, setSkill, 0, maxSkill)}>{text}</button>
-    )
-  }
-
-  const BloodtingeButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(bloodtinge + value, setBloodtinge, 0, maxBloodtinge)}>{text}</button>
-    )
-  }
-
-  const ArcaneButton = ({value, text}: {value: number, text: string}) => {
-    return (
-      <button type="button" className={buttonClass} onClick={e => setValueWithValidation(arcane + value, setArcane, 0, maxArcane)}>{text}</button>
-    )
   }
 
   function generateURL(build: string, origin: number, vitality: number, endurance: number, strength: number, skill: number, bloodtinge: number, arcane: number): string {
@@ -340,11 +310,11 @@ export default function Simulator() {
                   {selectedOrigin.vitality + vitality}
                 </td>
                 <td>
-                  <VitalityButton value={-10} text="-10"/>
-                  <VitalityButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={vitality} value={-10} max={maxVitality} text='-10' setValue={setVitality} />
+                  <IncreaseAndDecreaseButton currentValue={vitality} value={-1} max={maxVitality} text='-1' setValue={setVitality} />
                   <Slider value={vitality} max={maxVitality} setValue={setVitality}/>
-                  <VitalityButton value={+1} text="+1"/>
-                  <VitalityButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={vitality} value={+1} max={maxVitality} text='+1' setValue={setVitality} />
+                  <IncreaseAndDecreaseButton currentValue={vitality} value={+10} max={maxVitality} text='+10' setValue={setVitality} />
                 </td>
               </tr>
 
@@ -354,11 +324,11 @@ export default function Simulator() {
                   {selectedOrigin.endurance + endurance}
                 </td>
                 <td>
-                  <EnduranceButton value={-10} text="-10"/>
-                  <EnduranceButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={endurance} value={-10} max={maxEndurance} text='-10' setValue={setEndurance} />
+                  <IncreaseAndDecreaseButton currentValue={endurance} value={-1} max={maxEndurance} text='-1' setValue={setEndurance} />
                   <Slider value={endurance} max={maxEndurance} setValue={setEndurance}/>
-                  <EnduranceButton value={+1} text="+1"/>
-                  <EnduranceButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={endurance} value={+1} max={maxEndurance} text='+1' setValue={setEndurance} />
+                  <IncreaseAndDecreaseButton currentValue={endurance} value={+10} max={maxEndurance} text='+10' setValue={setEndurance} />
                 </td>
               </tr>
 
@@ -368,11 +338,11 @@ export default function Simulator() {
                   {selectedOrigin.strength + strength}
                 </td>
                 <td>
-                  <StrengthButton value={-10} text="-10"/>
-                  <StrengthButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={strength} value={-10} max={maxStrength} text='-10' setValue={setStrength} />
+                  <IncreaseAndDecreaseButton currentValue={strength} value={-1} max={maxStrength} text='-1' setValue={setStrength} />
                   <Slider value={strength} max={maxStrength} setValue={setStrength}/>
-                  <StrengthButton value={+1} text="+1"/>
-                  <StrengthButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={strength} value={+1} max={maxStrength} text='+1' setValue={setStrength} />
+                  <IncreaseAndDecreaseButton currentValue={strength} value={+10} max={maxStrength} text='+10' setValue={setStrength} />
                 </td>
               </tr>
 
@@ -382,11 +352,11 @@ export default function Simulator() {
                   {selectedOrigin.skill + skill}
                 </td>
                 <td>
-                  <SkillButton value={-10} text="-10"/>
-                  <SkillButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={skill} value={-10} max={maxSkill} text='-10' setValue={setSkill} />
+                  <IncreaseAndDecreaseButton currentValue={skill} value={-1} max={maxSkill} text='-1' setValue={setSkill} />
                   <Slider value={skill} max={maxSkill} setValue={setSkill}/>
-                  <SkillButton value={+1} text="+1"/>
-                  <SkillButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={skill} value={+1} max={maxSkill} text='+1' setValue={setSkill} />
+                  <IncreaseAndDecreaseButton currentValue={skill} value={+10} max={maxSkill} text='+10' setValue={setSkill} />
                 </td>
               </tr>
 
@@ -396,11 +366,11 @@ export default function Simulator() {
                   {selectedOrigin.bloodtinge + bloodtinge}
                 </td>
                 <td>
-                  <BloodtingeButton value={-10} text="-10"/>
-                  <BloodtingeButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={-10} max={maxBloodtinge} text='-10' setValue={setBloodtinge} />
+                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={-1} max={maxBloodtinge} text='-1' setValue={setBloodtinge} />
                   <Slider value={bloodtinge} max={maxBloodtinge} setValue={setBloodtinge}/>
-                  <BloodtingeButton value={+1} text="+1"/>
-                  <BloodtingeButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={+1} max={maxBloodtinge} text='+1' setValue={setBloodtinge} />
+                  <IncreaseAndDecreaseButton currentValue={bloodtinge} value={+10} max={maxBloodtinge} text='+10' setValue={setBloodtinge} />
                 </td>
               </tr>
 
@@ -410,11 +380,11 @@ export default function Simulator() {
                   {selectedOrigin.arcane + arcane}
                 </td>
                 <td>
-                  <ArcaneButton value={-10} text="-10"/>
-                  <ArcaneButton value={-1} text="-1"/>
+                  <IncreaseAndDecreaseButton currentValue={arcane} value={-10} max={maxArcane} text='-10' setValue={setArcane} />
+                  <IncreaseAndDecreaseButton currentValue={arcane} value={-1} max={maxArcane} text='-1' setValue={setArcane} />
                   <Slider value={arcane} max={maxArcane} setValue={setArcane}/>
-                  <ArcaneButton value={+1} text="+1"/>
-                  <ArcaneButton value={+10} text="+10"/>
+                  <IncreaseAndDecreaseButton currentValue={arcane} value={+1} max={maxArcane} text='+1' setValue={setArcane} />
+                  <IncreaseAndDecreaseButton currentValue={arcane} value={+10} max={maxArcane} text='+10' setValue={setArcane} />
                 </td>
               </tr>
             </tbody>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -316,65 +316,26 @@ export default function Simulator() {
                 </td>
               </tr>
 
-              <tr>
-                <th>体力</th>
-                <td data-testid="vitalityText">
-                  {selectedOrigin.vitality + vitality}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={vitality} max={maxVitality} setValue={setVitality} />
-                </td>
-              </tr>
-
-              <tr>
-                <th>持久力</th>
-                <td data-testid="enduranceText">
-                  {selectedOrigin.endurance + endurance}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={endurance} max={maxEndurance} setValue={setEndurance} />
-                </td>
-              </tr>
-
-              <tr>
-                <th>筋力</th>
-                <td data-testid="strengthText">
-                  {selectedOrigin.strength + strength}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={strength} max={maxStrength} setValue={setStrength} />
-                </td>
-              </tr>
-
-              <tr>
-                <th>技術</th>
-                <td data-testid="skillText">
-                  {selectedOrigin.skill + skill}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={skill} max={maxSkill} setValue={setSkill} />
-                </td>
-              </tr>
-
-              <tr>
-                <th>血質</th>
-                <td data-testid="bloodtingeText">
-                  {selectedOrigin.bloodtinge + bloodtinge}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={bloodtinge} max={maxBloodtinge} setValue={setBloodtinge} />
-                </td>
-              </tr>
-
-              <tr>
-                <th>神秘</th>
-                <td data-testid="arcaneText">
-                  {selectedOrigin.arcane + arcane}
-                </td>
-                <td>
-                  <ChangeParameterInputs currentValue={arcane} max={maxArcane} setValue={setArcane} />
-                </td>
-              </tr>
+              {
+                [
+                  {desc: '体力', id: 'vitalityText', selected: selectedOrigin.vitality, currentValue: vitality, max: maxVitality, setValue: setVitality},
+                  {desc: '持久力', id: 'enduranceText', selected: selectedOrigin.endurance, currentValue: endurance, max: maxEndurance, setValue: setEndurance},
+                  {desc: '筋力', id: 'strengthText', selected: selectedOrigin.strength, currentValue: strength, max: maxStrength, setValue: setStrength},
+                  {desc: '技術', id: 'skillText', selected: selectedOrigin.skill, currentValue: skill, max: maxSkill, setValue: setSkill},
+                  {desc: '血質', id: 'bloodtingeText', selected: selectedOrigin.bloodtinge, currentValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
+                  {desc: '神秘', id: 'arcaneText', selected: selectedOrigin.arcane, currentValue: arcane, max: maxArcane, setValue: setArcane},
+                ].map((v) => (
+                  <tr key={v.id}>
+                    <th>{v.desc}</th>
+                    <td data-testid={v.id}>
+                      {v.selected + v.currentValue}
+                    </td>
+                    <td>
+                      <ChangeParameterInputs currentValue={v.currentValue} max={v.max} setValue={v.setValue} />
+                    </td>
+                  </tr>
+                ))
+              }
             </tbody>
           </table>
         </section>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -337,7 +337,13 @@ export default function Simulator() {
                       {v.baseValue + v.additionalValue}
                     </td>
                     <td>
-                      <ChangeParameterInputs statusName={v.desc} currentValue={v.baseValue + v.additionalValue} additionalValue={v.additionalValue} max={v.max} setValue={v.setValue} />
+                      <ChangeParameterInputs
+                        statusName={v.desc}
+                        currentValue={v.baseValue + v.additionalValue}
+                        additionalValue={v.additionalValue}
+                        max={v.max}
+                        setValue={v.setValue}
+                        />
                     </td>
                   </tr>
                 ))


### PR DESCRIPTION
## Feature

* ビルド名に `autoFocus` を追加
* ビルド名に `placeholder` を追加
* すべてのステータスに `aria-label` 属性を付与

## Hotfix

* キーボードでステータスの加算・減算ボタンを押下するとフォーカスが外れる不具合を修正

## Chore

* リファクタリング
  * 体力、持久力といったステータスごとにコンポーネントボタンを実装していたのを共通コンポーネントで統一
  * ベタ書きしていた slider input を Slider コンポーネントで共通化
  * 全ステータス分ベタでテーブル HTML を定義していたのを map loop で定義するように変更

## Ref

* [aria-label - MDN](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Attributes/aria-label)
* [placeholder - MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Attributes/placeholder)
  * アクセシビリティとしては、以下が重要そうだった
  * > 効果的なプレースホルダーテキストは、説明や質問ではなく、期待するデータの種類のヒントとなる単語や短いフレーズです。プレースホルダーを <label> のかわりに用いてはいけません。プレースホルダーはフォームコントロールの値が空でないときは見えないので、<label> のかわりに placeholder に質問を書くと使いやすさとアクセシビリティを損ねます。
* [[React]フォーム入力の度にフォーカスが外れてしまうときに確認すべきこと2選 - Qiita](https://qiita.com/shunexe/items/5d88e255f18280d6941d)

#16 