### PR TITLE
fix: 共有 URL を折りたたみから text input に変更 #16

### DIFF
--- a/src/app/simulator.test.tsx
+++ b/src/app/simulator.test.tsx
@@ -86,13 +86,18 @@ describe('正常系: クエリストリングが設定されている場合は',
             want: '98',
         },
         {
-            desc: 'URL がセットされている',
-            id: 'urlText',
-            want: 'undefined?bld=sushi&org=1&vit=2&end=3&str=4&skl=3&blt=1&arc=2',
+            desc: '固定文字列がセットされている',
+            id: 'urlTextLink',
+            want: '共有用 URL',
         },
     ]
     test.each(paramTests)(`$desc`, ({ id, want }) => {
         const got = container.querySelector<HTMLElement>(`[data-testid="${id}"]`)
         expect(got?.textContent).toBe(want)
+    })
+
+    test('共有用 text input には URL が defaultValue として設定される', () => {
+        const got = container.querySelector<HTMLInputElement>('[data-testid="urlTextInput"]')
+        expect(got?.defaultValue).toBe('undefined?bld=sushi&org=1&vit=2&end=3&str=4&skl=3&blt=1&arc=2')
     })
 })

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -304,6 +304,7 @@ export default function Simulator() {
         <section className="m-2 border-b-2 border-dotted">
           <h2 className="text-xl">入力</h2>
           <div className='m-4'>
+            <p className='m-1'>以下の入力値を変更すると、計算結果と共有に自動反映されます。</p>
             <table>
               <tbody>
                 <tr>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -392,7 +392,14 @@ export default function Simulator() {
               <div className='m-4'>
                 <ul className='list-disc'>
                   <li>
-                    <input data-testid="urlTextInput" className={textInputClass} type="text" defaultValue={shareURL} readOnly />
+                    <input
+                      data-testid="urlTextInput"
+                      className={textInputClass}
+                      type="text"
+                      defaultValue={shareURL}
+                      readOnly
+                      onFocus={e => e.target.select()}
+                      />
                     （<a data-testid="urlTextLink" className="text-cyan-300" href={shareURL}>共有用 URL</a>）
                   </li>
                 </ul>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -187,6 +187,7 @@ function setDocumentTitle(name: string) {
 
 const sliderClass = "w-28 md:w-40 lg:w-60 m-2"
 const buttonClass = "bg-white text-black p-0.5 md:p-1 m-0.5 md:m-1 rounded w-10 md:w-12"
+const textInputClass = "w-80 text-black p-1 rounded"
 
 function setValueWithValidation(value: number, setValue: any, min: number, max: number) {
   if (value < min) {
@@ -302,92 +303,102 @@ export default function Simulator() {
       <div className="border rounded p-2 text-sm md:text-base">
         <section className="m-2 border-b-2 border-dotted">
           <h2 className="text-xl">入力</h2>
-          <table className="m-4">
-            <tbody>
-              <tr>
-                <th className="w-20">ビルド名</th>
-                <td className="w-8"></td>
-                <td>
-                  <input className="w-80 text-black" type="text" value={buildName} autoFocus placeholder='例：上質ビルド' aria-label='分かりやすいビルド名を入力します' onChange={e => setBuildName(e.target.value)} />
-                </td>
-              </tr>
+          <div className='m-4'>
+            <table>
+              <tbody>
+                <tr>
+                  <th className="w-20">ビルド名</th>
+                  <td className="w-8"></td>
+                  <td>
+                    <input className={textInputClass} type="text" value={buildName} autoFocus placeholder='例：上質ビルド' aria-label='分かりやすいビルド名を入力します' onChange={e => setBuildName(e.target.value)} />
+                  </td>
+                </tr>
 
-              <tr>
-                <th>過去</th>
-                <td></td>
-                <td>
-                  <select data-testid="originText" className="text-black" value={selected} aria-label='過去を選択します' onChange={e => resetStatus(e.target.value)}>
-                    {
-                      numberToOrigin.map((v,i) => <option key={v.key} value={v.key}>{v.name}</option>)
-                    }
-                  </select>
-                </td>
-              </tr>
+                <tr>
+                  <th>過去</th>
+                  <td></td>
+                  <td>
+                    <select data-testid="originText" className="text-black p-1 rounded" value={selected} aria-label='過去を選択します' onChange={e => resetStatus(e.target.value)}>
+                      {
+                        numberToOrigin.map((v,i) => <option key={v.key} value={v.key}>{v.name}</option>)
+                      }
+                    </select>
+                  </td>
+                </tr>
 
-              {
-                [
-                  {desc: '体力', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
-                  {desc: '持久力', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
-                  {desc: '筋力', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
-                  {desc: '技術', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
-                  {desc: '血質', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
-                  {desc: '神秘', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
-                ].map((v) => (
-                  <tr key={v.id}>
-                    <th>{v.desc}</th>
-                    <td data-testid={v.id}>
-                      {v.baseValue + v.additionalValue}
-                    </td>
-                    <td>
-                      <ChangeParameterInputs
-                        statusName={v.desc}
-                        currentValue={v.baseValue + v.additionalValue}
-                        additionalValue={v.additionalValue}
-                        max={v.max}
-                        setValue={v.setValue}
-                        />
-                    </td>
-                  </tr>
-                ))
-              }
-            </tbody>
-          </table>
+                {
+                  [
+                    {desc: '体力', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
+                    {desc: '持久力', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
+                    {desc: '筋力', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
+                    {desc: '技術', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
+                    {desc: '血質', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
+                    {desc: '神秘', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
+                  ].map((v) => (
+                    <tr key={v.id}>
+                      <th>{v.desc}</th>
+                      <td data-testid={v.id}>
+                        {v.baseValue + v.additionalValue}
+                      </td>
+                      <td>
+                        <ChangeParameterInputs
+                          statusName={v.desc}
+                          currentValue={v.baseValue + v.additionalValue}
+                          additionalValue={v.additionalValue}
+                          max={v.max}
+                          setValue={v.setValue}
+                          />
+                      </td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
         </section>
 
         <section className="m-2">
           <h2 className="text-xl">計算結果</h2>
-          <table className="m-4">
-            <tbody>
-              <tr>
-                <th>レベル</th>
-                <td data-testid="levelText">{selectedOrigin.level + vitality + endurance + strength + skill + bloodtinge + arcane}</td>
-              </tr>
+          <div className="m-4">
+            <table>
+              <tbody>
+                <tr>
+                  <th>レベル</th>
+                  <td data-testid="levelText">{selectedOrigin.level + vitality + endurance + strength + skill + bloodtinge + arcane}</td>
+                </tr>
 
-              <tr>
-                <th>HP</th>
-                <td data-testid="hpText">{HPs[selectedOrigin.vitality + vitality]}</td>
-              </tr>
+                <tr>
+                  <th>HP</th>
+                  <td data-testid="hpText">{HPs[selectedOrigin.vitality + vitality]}</td>
+                </tr>
 
-              <tr>
-                <th>スタミナ</th>
-                <td data-testid="staminaText">{Staminas[selectedOrigin.endurance + endurance]}</td>
-              </tr>
-            </tbody>
-          </table>
+                <tr>
+                  <th>スタミナ</th>
+                  <td data-testid="staminaText">{Staminas[selectedOrigin.endurance + endurance]}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </section>
 
         <section className="m-2">
           <h2 className="text-xl">共有</h2>
-          <p className="m-4">
-            以下のURLをブックマークすることで、今のビルドを保存できます。<br/>
-            URLをコピーして共有すれば、他の人にビルドを紹介できます。
-          </p>
-          <details>
-            <summary>折りたたみを展開する</summary>
-            <p className="m-4 w-80 break-words">
-              <a data-testid="urlText" className="text-cyan-300" href={shareURL}>{shareURL}</a>
-            </p>
-          </details>
+          <div className='m-4'>
+            <label>
+              <p>
+                以下のURLをブックマークすることで、今のビルドを保存できます。<br/>
+                URLをコピーして共有すれば、他の人にビルドを紹介できます。
+              </p>
+              <div className='m-4'>
+                <ul className='list-disc'>
+                  <li>
+                    <input className={textInputClass} type="text" defaultValue={shareURL} readOnly />
+                    （<a data-testid="urlText" className="text-cyan-300" href={shareURL}>共有用 URL</a>）
+                  </li>
+                </ul>
+              </div>
+            </label>
+          </div>
         </section>
       </div>
 

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -302,12 +302,12 @@ export default function Simulator() {
 
       <div className="border rounded p-2 text-sm md:text-base">
         <section className="m-2 border-b-2 border-dotted">
-          <h2 className="text-xl">入力</h2>
+          <h2 className="text-xl"><ruby>入力<rp>(</rp><rt>にゅうりょく</rt><rp>)</rp></ruby></h2>
           <div className='m-4'>
             <table>
               <tbody>
                 <tr>
-                  <th className="w-20">ビルド名</th>
+                  <th className="w-20">ビルド<ruby>名<rp>(</rp><rt>めい</rt><rp>)</rp></ruby></th>
                   <td className="w-8"></td>
                   <td>
                     <input className={textInputClass} type="text" value={buildName} autoFocus placeholder='例：上質ビルド' aria-label='分かりやすいビルド名を入力します' onChange={e => setBuildName(e.target.value)} />
@@ -315,7 +315,7 @@ export default function Simulator() {
                 </tr>
 
                 <tr>
-                  <th>過去</th>
+                  <th><ruby>過去<rp>(</rp><rt>かこ</rt><rp>)</rp></ruby></th>
                   <td></td>
                   <td>
                     <select data-testid="originText" className="text-black p-1 rounded" value={selected} aria-label='過去を選択します' onChange={e => resetStatus(e.target.value)}>
@@ -328,15 +328,20 @@ export default function Simulator() {
 
                 {
                   [
-                    {desc: '体力', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
-                    {desc: '持久力', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
-                    {desc: '筋力', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
-                    {desc: '技術', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
-                    {desc: '血質', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
-                    {desc: '神秘', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
+                    {desc: '体力', ruby: 'たいりょく', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
+                    {desc: '持久力', ruby: 'じきゅうりょく', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
+                    {desc: '筋力', ruby: 'きんりょく', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
+                    {desc: '技術', ruby: 'ぎじゅつ', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
+                    {desc: '血質', ruby: 'けっしつ', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
+                    {desc: '神秘', ruby: 'しんぴ', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
                   ].map((v) => (
                     <tr key={v.id}>
-                      <th>{v.desc}</th>
+                      <th>
+                        <ruby>
+                          {v.desc}
+                          <rp>(</rp><rt>{v.ruby}</rt><rp>)</rp>
+                        </ruby>
+                      </th>
                       <td data-testid={v.id}>
                         {v.baseValue + v.additionalValue}
                       </td>
@@ -358,7 +363,7 @@ export default function Simulator() {
         </section>
 
         <section className="m-2">
-          <h2 className="text-xl">計算結果</h2>
+          <h2 className="text-xl"><ruby>計算結果<rp>(</rp><rt>けいさんけっか</rt><rp>)</rp></ruby></h2>
           <div className="m-4">
             <table>
               <tbody>
@@ -382,12 +387,14 @@ export default function Simulator() {
         </section>
 
         <section className="m-2">
-          <h2 className="text-xl">共有</h2>
+          <h2 className="text-xl"><ruby>共有<rp>(</rp><rt>きょうゆう</rt><rp>)</rp></ruby></h2>
           <div className='m-4'>
             <label>
               <p>
-                以下の URL をブックマークすることで、今のビルドを保存できます。<br/>
-                URL をコピーして共有すれば、他の人にビルドを紹介できます。
+                <ruby>以下<rp>(</rp><rt>いか</rt><rp>)</rp></ruby>の URL をブックマークすることで、
+                <ruby>今<rp>(</rp><rt>いま</rt><rp>)</rp></ruby>のビルドを<ruby>保存<rp>(</rp><rt>ほぞん</rt><rp>)</rp></ruby>できます。<br/>
+                URL をコピーして<ruby>共有<rp>(</rp><rt>きょうゆう</rt><rp>)</rp></ruby>すれば、
+                <ruby>他<rp>(</rp><rt>ほか</rt><rp>)</rp></ruby>の<ruby>人<rp>(</rp><rt>ひと</rt><rp>)</rp></ruby>にビルドを<ruby>紹介<rp>(</rp><rt>しょうかい</rt><rp>)</rp></ruby>できます。
               </p>
               <div className='m-4'>
                 <ul className='list-disc'>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -392,8 +392,8 @@ export default function Simulator() {
               <div className='m-4'>
                 <ul className='list-disc'>
                   <li>
-                    <input className={textInputClass} type="text" defaultValue={shareURL} readOnly />
-                    （<a data-testid="urlText" className="text-cyan-300" href={shareURL}>共有用 URL</a>）
+                    <input data-testid="urlTextInput" className={textInputClass} type="text" defaultValue={shareURL} readOnly />
+                    （<a data-testid="urlTextLink" className="text-cyan-300" href={shareURL}>共有用 URL</a>）
                   </li>
                 </ul>
               </div>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -302,12 +302,12 @@ export default function Simulator() {
 
       <div className="border rounded p-2 text-sm md:text-base">
         <section className="m-2 border-b-2 border-dotted">
-          <h2 className="text-xl"><ruby>入力<rp>(</rp><rt>にゅうりょく</rt><rp>)</rp></ruby></h2>
+          <h2 className="text-xl">入力</h2>
           <div className='m-4'>
             <table>
               <tbody>
                 <tr>
-                  <th className="w-20">ビルド<ruby>名<rp>(</rp><rt>めい</rt><rp>)</rp></ruby></th>
+                  <th className="w-20">ビルド名</th>
                   <td className="w-8"></td>
                   <td>
                     <input className={textInputClass} type="text" value={buildName} autoFocus placeholder='例：上質ビルド' aria-label='分かりやすいビルド名を入力します' onChange={e => setBuildName(e.target.value)} />
@@ -315,7 +315,7 @@ export default function Simulator() {
                 </tr>
 
                 <tr>
-                  <th><ruby>過去<rp>(</rp><rt>かこ</rt><rp>)</rp></ruby></th>
+                  <th>過去</th>
                   <td></td>
                   <td>
                     <select data-testid="originText" className="text-black p-1 rounded" value={selected} aria-label='過去を選択します' onChange={e => resetStatus(e.target.value)}>
@@ -328,20 +328,15 @@ export default function Simulator() {
 
                 {
                   [
-                    {desc: '体力', ruby: 'たいりょく', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
-                    {desc: '持久力', ruby: 'じきゅうりょく', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
-                    {desc: '筋力', ruby: 'きんりょく', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
-                    {desc: '技術', ruby: 'ぎじゅつ', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
-                    {desc: '血質', ruby: 'けっしつ', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
-                    {desc: '神秘', ruby: 'しんぴ', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
+                    {desc: '体力', id: 'vitalityText', baseValue: selectedOrigin.vitality, additionalValue: vitality, max: maxVitality, setValue: setVitality},
+                    {desc: '持久力', id: 'enduranceText', baseValue: selectedOrigin.endurance, additionalValue: endurance, max: maxEndurance, setValue: setEndurance},
+                    {desc: '筋力', id: 'strengthText', baseValue: selectedOrigin.strength, additionalValue: strength, max: maxStrength, setValue: setStrength},
+                    {desc: '技術', id: 'skillText', baseValue: selectedOrigin.skill, additionalValue: skill, max: maxSkill, setValue: setSkill},
+                    {desc: '血質', id: 'bloodtingeText', baseValue: selectedOrigin.bloodtinge, additionalValue: bloodtinge, max: maxBloodtinge, setValue: setBloodtinge},
+                    {desc: '神秘', id: 'arcaneText', baseValue: selectedOrigin.arcane, additionalValue: arcane, max: maxArcane, setValue: setArcane},
                   ].map((v) => (
                     <tr key={v.id}>
-                      <th>
-                        <ruby>
-                          {v.desc}
-                          <rp>(</rp><rt>{v.ruby}</rt><rp>)</rp>
-                        </ruby>
-                      </th>
+                      <th>{v.desc}</th>
                       <td data-testid={v.id}>
                         {v.baseValue + v.additionalValue}
                       </td>
@@ -363,7 +358,7 @@ export default function Simulator() {
         </section>
 
         <section className="m-2">
-          <h2 className="text-xl"><ruby>計算結果<rp>(</rp><rt>けいさんけっか</rt><rp>)</rp></ruby></h2>
+          <h2 className="text-xl">計算結果</h2>
           <div className="m-4">
             <table>
               <tbody>
@@ -387,14 +382,12 @@ export default function Simulator() {
         </section>
 
         <section className="m-2">
-          <h2 className="text-xl"><ruby>共有<rp>(</rp><rt>きょうゆう</rt><rp>)</rp></ruby></h2>
+          <h2 className="text-xl">共有</h2>
           <div className='m-4'>
             <label>
               <p>
-                <ruby>以下<rp>(</rp><rt>いか</rt><rp>)</rp></ruby>の URL をブックマークすることで、
-                <ruby>今<rp>(</rp><rt>いま</rt><rp>)</rp></ruby>のビルドを<ruby>保存<rp>(</rp><rt>ほぞん</rt><rp>)</rp></ruby>できます。<br/>
-                URL をコピーして<ruby>共有<rp>(</rp><rt>きょうゆう</rt><rp>)</rp></ruby>すれば、
-                <ruby>他<rp>(</rp><rt>ほか</rt><rp>)</rp></ruby>の<ruby>人<rp>(</rp><rt>ひと</rt><rp>)</rp></ruby>にビルドを<ruby>紹介<rp>(</rp><rt>しょうかい</rt><rp>)</rp></ruby>できます。
+                以下の URL をブックマークすることで、今のビルドを保存できます。<br/>
+                URL をコピーして共有すれば、他の人にビルドを紹介できます。
               </p>
               <div className='m-4'>
                 <ul className='list-disc'>

--- a/src/app/simulator.tsx
+++ b/src/app/simulator.tsx
@@ -386,8 +386,8 @@ export default function Simulator() {
           <div className='m-4'>
             <label>
               <p>
-                以下のURLをブックマークすることで、今のビルドを保存できます。<br/>
-                URLをコピーして共有すれば、他の人にビルドを紹介できます。
+                以下の URL をブックマークすることで、今のビルドを保存できます。<br/>
+                URL をコピーして共有すれば、他の人にビルドを紹介できます。
               </p>
               <div className='m-4'>
                 <ul className='list-disc'>


### PR DESCRIPTION
## Feature

* 共有 URL をおりたたみから text input に変更
* text input に label を紐づけた
* 入力セクションに説明文を追加

## Chore

* text input の css を調整
* section 内に div を追加してレイアウト定義を移動

## Note

* ルビを付与しようとした(0ccd4b760cf7a708220d92f80d3309c51e99c216)けれど、ブラボをプレイする人ならこのくらいの漢字は読めると思うのでやっぱりやめた
* あとルビを付与することで画面がやや縦長になってしまい、スクロールバーが表示されるのが嫌だったから

#16 